### PR TITLE
Implement poppler.Load() to create PopplerDocument from data

### DIFF
--- a/poppler.go
+++ b/poppler.go
@@ -10,6 +10,7 @@ import "C"
 import (
 	"errors"
 	"path/filepath"
+	"unsafe"
 )
 
 type poppDoc *C.struct__PopplerDocument
@@ -28,6 +29,19 @@ func Open(filename string) (doc *Document, err error) {
 	}
 	doc = &Document{
 		doc : d,
+	}
+	return
+}
+
+func Load(data []byte) (doc *Document, err error) {
+	var e *C.GError
+	var d poppDoc
+	d = C.poppler_document_new_from_data((*C.char)(unsafe.Pointer(&data[0])), (C.int)(len(data)), nil, &e)
+	if e != nil {
+		err = errors.New(C.GoString((*C.char)(e.message)))
+	}
+	doc = &Document{
+		doc: d,
 	}
 	return
 }


### PR DESCRIPTION
This is a wrapper around [poppler_document_new_from_data()](https://developer.gnome.org/poppler/0.16/PopplerDocument.html#poppler-document-new-from-data), which takes file bytes as input instead of filename.

I faced the problem with `poppler.Open(filename)` that it raises "too many open files" error in the bulk/concurrent PDF processing, and it was difficult to resolve the issue as it seems we cannot close the file opened with `poppler_document_new_from_file()` (cf. <https://github.com/ruby-gnome/ruby-gnome/issues/732>).
 
Creating PopplerDocument from data would be helpful to have a control over file open/close on the Go side.

Thank you for maintaining the nice library!
