### PR TITLE
Add close func to avoid fd leak

### DIFF
--- a/document.go
+++ b/document.go
@@ -8,7 +8,8 @@ package poppler
 import "C"
 
 type Document struct {
-	doc poppDoc
+	doc                poppDoc
+	openedPopplerPages []*C.struct__PopplerPage
 }
 
 type DocumentInfo struct {
@@ -40,6 +41,7 @@ func (d *Document) GetNPages() int {
 
 func (d *Document) GetPage(i int) (page *Page) {
 	p := C.poppler_document_get_page(d.doc, C.int(i))
+	d.openedPopplerPages = append(d.openedPopplerPages, p)
 	return &Page{p: p}
 }
 
@@ -49,6 +51,14 @@ func (d *Document) HasAttachments() bool {
 
 func (d *Document) GetNAttachments() int {
 	return int(C.poppler_document_get_n_attachments(d.doc))
+}
+
+func (d *Document) Close() {
+	for i := 0; i < len(d.openedPopplerPages); i++ {
+		C.g_object_unref(C.gpointer(d.openedPopplerPages[i]))
+	}
+	d.openedPopplerPages = []*C.struct__PopplerPage{}
+	C.g_object_unref(C.gpointer(d.doc))
 }
 
 /*

--- a/page.go
+++ b/page.go
@@ -5,6 +5,7 @@ package poppler
 // #include <glib.h>
 import "C"
 import "unsafe"
+
 //import "fmt"
 
 type Page struct {
@@ -20,7 +21,7 @@ func (p *Page) TextAttributes() (results []TextAttributes) {
 	defer C.poppler_page_free_text_attributes(a)
 	var attr *C.PopplerTextAttributes
 	results = make([]TextAttributes, 0)
-	el := C.g_list_first(a);
+	el := C.g_list_first(a)
 	for el != nil {
 		attr = (*C.PopplerTextAttributes)(el.data)
 		fn := *attr.font_name
@@ -88,7 +89,7 @@ func (p *Page) TextLayout() (layouts []Rectangle) {
 	if toBool(C.poppler_page_get_text_layout(p.p, &rect, &n)) {
 		defer C.g_free((C.gpointer)(rect))
 		layouts = make([]Rectangle, int(n))
-        r := (*[1 << 30]C.PopplerRectangle)(unsafe.Pointer(rect))[:n:n]
+		r := (*[1 << 30]C.PopplerRectangle)(unsafe.Pointer(rect))[:n:n]
 		for i := 0; i < int(n); i++ {
 			layouts[i] = Rectangle{
 				X1: float64(r[i].x1),
@@ -101,12 +102,11 @@ func (p *Page) TextLayout() (layouts []Rectangle) {
 	return
 }
 
-
 func (p *Page) TextLayoutAndAttrs() (result []TextEl) {
 	text := p.Text()
 	attrs := p.TextAttributes()
 	layout := p.TextLayout()
-	result = make([]TextEl, len(layout))	
+	result = make([]TextEl, len(layout))
 	attrsRef := make([]*TextAttributes, len(attrs))
 	for i, a := range attrs {
 		attr := a
@@ -121,11 +121,15 @@ func (p *Page) TextLayoutAndAttrs() (result []TextEl) {
 			}
 		}
 		result[i] = TextEl{
-			Text : string(t),
+			Text:  string(t),
 			Attrs: a,
-			Rect : layout[i],
+			Rect:  layout[i],
 		}
 		i++
 	}
 	return
+}
+
+func (p *Page) Close() {
+	C.g_object_unref(C.gpointer(p.p))
 }

--- a/poppler.go
+++ b/poppler.go
@@ -14,20 +14,21 @@ import (
 
 type poppDoc *C.struct__PopplerDocument
 
-func Open(filename string) (doc *Document, err error) {	
+func Open(filename string) (doc *Document, err error) {
 	filename, err = filepath.Abs(filename)
 	if err != nil {
 		return
 	}
 	var e *C.GError
-	fn := C.g_filename_to_uri((*C.gchar)(C.CString(filename)), nil, nil);
+	fn := C.g_filename_to_uri((*C.gchar)(C.CString(filename)), nil, nil)
 	var d poppDoc
 	d = C.poppler_document_new_from_file((*C.char)(fn), nil, &e)
 	if e != nil {
 		err = errors.New(C.GoString((*C.char)(e.message)))
 	}
 	doc = &Document{
-		doc : d,
+		doc:                d,
+		openedPopplerPages: []*C.struct__PopplerPage{},
 	}
 	return
 }


### PR DESCRIPTION
Fix #7 by adding `doc.Close()` method.

How to use
```
for i := 0; i < 300; i++ {
	fmt.Println(i)
	doc, _ := poppler.Open("../pdf-to-text/pdf_jetstar/BLDVND190576798475400001.pdf")
	page := doc.GetPage(0)
	page.Text()
	doc.Close() // This will unref all opened pages & the poppler doc
}
```