### PR TITLE
Remove deprecation warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/cheggaaa/go-poppler
+
+go 1.16
+
+require github.com/ungerik/go-cairo v0.0.0-20210317133935-984b32e6bac6

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/ungerik/go-cairo v0.0.0-20210317133935-984b32e6bac6 h1:KrKqo3an56mwfObaZtHlyhN+IVDyw1XaoIT5Cr2Ttvk=
+github.com/ungerik/go-cairo v0.0.0-20210317133935-984b32e6bac6/go.mod h1:yLTJg56omDJ+JVxZ5whpCrZgQdaSs+OBdFa+X6ViJcI=

--- a/image.go
+++ b/image.go
@@ -4,8 +4,11 @@ package poppler
 // #include <poppler.h>
 // #include <glib.h>
 import "C"
-import "unsafe"
-import "github.com/ungerik/go-cairo"
+import (
+	"unsafe"
+
+	"github.com/ungerik/go-cairo"
+)
 
 // Image
 

--- a/poppler.go
+++ b/poppler.go
@@ -37,7 +37,11 @@ func Open(filename string) (doc *Document, err error) {
 func Load(data []byte) (doc *Document, err error) {
 	var e *C.GError
 	var d poppDoc
-	d = C.poppler_document_new_from_data((*C.char)(unsafe.Pointer(&data[0])), (C.int)(len(data)), nil, &e)
+
+	b := C.g_bytes_new((C.gconstpointer)(unsafe.Pointer(&data[0])), (C.ulong)(len(data)))
+	defer C.g_bytes_unref(b)
+
+	d = C.poppler_document_new_from_bytes(b, nil, &e)
 	if e != nil {
 		err = errors.New(C.GoString((*C.char)(e.message)))
 	}


### PR DESCRIPTION
`poppler_document_new_from_data` has been deprecated, these commits move it to use `poppler_document_new_from_bytes`.