### PR TITLE
Fix Font Name Issue

### DIFF
--- a/page.go
+++ b/page.go
@@ -24,9 +24,9 @@ func (p *Page) TextAttributes() (results []TextAttributes) {
 	el := C.g_list_first(a)
 	for el != nil {
 		attr = (*C.PopplerTextAttributes)(el.data)
-		fn := *attr.font_name
+		fn := attr.font_name
 		result := TextAttributes{
-			FontName:     toString(&fn),
+			FontName:     toString(fn),
 			FontSize:     float64(attr.font_size),
 			IsUnderlined: toBool(attr.is_underlined),
 			StartIndex:   int(attr.start_index),


### PR DESCRIPTION
* Currently all font names are truncated to just the first character.
* This is because a `char *` is dereferenced to make a local copy of the first character in the string
* Then the address of this local character is passed to the `toString` function.
* This PR fixes this