### PR TITLE
Added generic support for annotations

### DIFF
--- a/annot.go
+++ b/annot.go
@@ -1,0 +1,19 @@
+package poppler
+
+// #cgo pkg-config: poppler-glib
+// #include <poppler.h>
+// #include <glib.h>
+// #include <cairo.h>
+import "C"
+//import "unsafe"
+//import "github.com/ungerik/go-cairo"
+
+//import "fmt"
+
+type Annot struct {
+	am *C.struct__PopplerAnnotMapping 
+}
+
+func (a *Annot) Close() {
+	C.poppler_annot_mapping_free((*C.struct__PopplerAnnotMapping)(a.am))
+}

--- a/document.go
+++ b/document.go
@@ -42,7 +42,12 @@ func (d *Document) GetNPages() int {
 func (d *Document) GetPage(i int) (page *Page) {
 	p := C.poppler_document_get_page(d.doc, C.int(i))
 	d.openedPopplerPages = append(d.openedPopplerPages, p)
-	return &Page{p: p}
+	
+	page = &Page{
+		p:                p,
+		openedPopplerAnnotMappings: []*C.struct__PopplerAnnotMapping{},
+	}
+	return page
 }
 
 func (d *Document) HasAttachments() bool {


### PR DESCRIPTION
Added minimal support for annotations.

`annot` is a wrapper over PopplerAnnotMapping, since in the future annot properties can be accessed via the PopplerAnnot pointer of the PopplerAnnotMapping struct. 

`GetAnnots()` struct method for the Page struct retrieve a slice of `annot` 