### PR TITLE
Added functionality add/remove annotations

### DIFF
--- a/annot.go
+++ b/annot.go
@@ -143,6 +143,7 @@ func (a *Annot) Quads() []Quad {
 
 func (a *Annot) Close() {
 	C.poppler_annot_mapping_free((*C.struct__PopplerAnnotMapping)(a.am))
+	a.am = nil
 }
 
 func (a *Annot) SetColor(c Color){

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,13 @@
 package poppler
 
+// #cgo pkg-config: poppler-glib
+// #include <poppler.h>
 // #include <glib.h>
 // #include <unistd.h>
 // #include <stdlib.h>
 import "C"
+
+import "unsafe"
 
 func toString(in *C.gchar) string {
 	return C.GoString((*C.char)(in))
@@ -11,4 +15,72 @@ func toString(in *C.gchar) string {
 
 func toBool(in C.gboolean) bool {
 	return  int(in) > 0
+}
+
+/* convert a Quad struct to a GArray */
+func quadsToGArray(quads []Quad) *C.GArray {
+	garray := C.g_array_new(C.FALSE, C.FALSE, C.sizeof_PopplerQuadrilateral)
+
+	for _, quad := range quads {
+		item := C.PopplerQuadrilateral{
+			p1: C.PopplerPoint{
+				x: C.double(quad.P1.X),
+				y: C.double(quad.P1.Y),
+			},
+			p2: C.PopplerPoint{
+				x: C.double(quad.P2.X),
+				y: C.double(quad.P2.Y),
+			},
+			p3: C.PopplerPoint{
+				x: C.double(quad.P3.X),
+				y: C.double(quad.P3.Y),
+			},
+			p4: C.PopplerPoint{
+				x: C.double(quad.P4.X),
+				y: C.double(quad.P4.Y),
+			},
+		}
+
+		C.g_array_append_vals(garray, C.gconstpointer(&item),1)
+	}
+
+	return garray
+}
+
+/* convert a GArray to a quad */
+func gArrayToQuads(q *C.GArray) []Quad {
+	length := int(q.len)
+
+	quads := make([]Quad, length)
+
+	for i := 0; i < length; i++ {
+		item := (*C.PopplerQuadrilateral)(unsafe.Pointer(uintptr(unsafe.Pointer(q.data)) + uintptr(i)*unsafe.Sizeof(C.PopplerQuadrilateral{})))
+		quads[i] = Quad{
+			P1: Point{X: float64(item.p1.x), Y: float64(item.p1.y)},
+			P2: Point{X: float64(item.p2.x), Y: float64(item.p2.y)},
+			P3: Point{X: float64(item.p3.x), Y: float64(item.p3.y)},
+			P4: Point{X: float64(item.p4.x), Y: float64(item.p4.y)},
+		}
+	}
+
+	return quads
+}
+
+func rectangleToPopplerRectangle (r Rectangle) C.PopplerRectangle {
+	var pRect C.PopplerRectangle
+
+	pRect.x1 = C.double(r.X1)
+	pRect.y1 = C.double(r.Y1)
+	pRect.x2 = C.double(r.X2)
+	pRect.y2 = C.double(r.Y2)
+
+	return pRect
+}
+
+func gFree(mem interface{}) {
+	p, ok := mem.(unsafe.Pointer)
+	if !ok {
+		panic("gFree argument should be castable to unsafe.Pointer")
+	}
+	C.g_free(C.gpointer(p))
 }


### PR DESCRIPTION
and Save document.

- Reintroduced `Close()` on Annot
- Added `NewAnnot()` and `Save()` to Document
- Added `AddAnnot()` and `RemoveAnnot()` on Page
- Added `SetColor()`, `SetContents()` and `SetFlags()` on Annot
- fixed double free error on `Page.Close()` (double free occurs in `Doc.Close()`) by setting pointer to `nil`

 On branch feature/annotations-support
 Changes to be committed:
	modified:   annot.go
	modified:   document.go
	modified:   page.go
	modified:   utils.go