### PR TITLE
Some Fixes, added tests

### DIFF
--- a/annot.go
+++ b/annot.go
@@ -5,10 +5,15 @@ package poppler
 // #include <glib.h>
 // #include <cairo.h>
 //
-//PopplerAnnotTextMarkup *wrap_POPPLER_ANNOT_TEXT_MARKUP(PopplerAnnot *annot) {
-//  return POPPLER_ANNOT_TEXT_MARKUP(annot);
-//}
+// /* macro wrappings */
+// gboolean wrap_POPPLER_IS_ANNOT_TEXT_MARKUP(PopplerAnnot *annot){
+//   return POPPLER_IS_ANNOT_TEXT_MARKUP(annot);
+// }
+// PopplerAnnotTextMarkup *wrap_POPPLER_ANNOT_TEXT_MARKUP(PopplerAnnot *annot) {
+//	return POPPLER_ANNOT_TEXT_MARKUP(annot);
+// }
 import "C"
+
 import "unsafe"
 //import "github.com/ungerik/go-cairo"
 
@@ -114,6 +119,7 @@ func (a *Annot) Color() Color {
 
 	return color
 }
+
 func (a *Annot) Name() string {
 	cText := C.poppler_annot_get_name(a.am.annot)
 	return C.GoString(cText)
@@ -130,23 +136,48 @@ func (a *Annot) Flags() AnnotFlag {
 }
 
 func (a *Annot) Quads() []Quad {
+	if C.wrap_POPPLER_IS_ANNOT_TEXT_MARKUP(a.am.annot) == C.FALSE {
+		return nil
+	}
+
+
 	textMarkup := C.wrap_POPPLER_ANNOT_TEXT_MARKUP(a.am.annot)
 
 	q := C.poppler_annot_text_markup_get_quadrilaterals(textMarkup)
-	defer C.g_array_free(q, 1)
-	length := int(q.len)
 
-	quads := make([]Quad, length)
+	quads := gArrayToQuads(q)
 
-	for i := 0; i < length; i++ {
-		item := (*C.PopplerQuadrilateral)(unsafe.Pointer(uintptr(unsafe.Pointer(q.data)) + uintptr(i)*unsafe.Sizeof(C.PopplerQuadrilateral{})))
-		quads[i] = Quad{
-			P1: Point{X: float64(item.p1.x), Y: float64(item.p1.y)},
-			P2: Point{X: float64(item.p2.x), Y: float64(item.p2.y)},
-			P3: Point{X: float64(item.p3.x), Y: float64(item.p3.y)},
-			P4: Point{X: float64(item.p4.x), Y: float64(item.p4.y)},
-		}
-	}
+	C.g_array_free(q, 1)
 
 	return quads
+}
+
+func (a *Annot) Close() {
+	if a.am != nil {
+		C.poppler_annot_mapping_free(a.am)
+		a.am = nil
+	}
+}
+
+func (a *Annot) SetColor(c Color){
+	pColor := C.poppler_color_new()
+	pColor.red = C.ushort(c.R)
+	pColor.green = C.ushort(c.G)
+	pColor.blue = C.ushort(c.B)
+	defer gFree(pColor)
+
+	C.poppler_annot_set_color(a.am.annot, pColor )
+}
+
+func (a *Annot) SetContents(c string){
+	cStr := C.CString(c)
+	defer C.free(unsafe.Pointer(cStr))
+
+	C.poppler_annot_set_contents(a.am.annot, cStr)
+}
+
+func  (a *Annot) SetFlags(f AnnotFlag){
+	pFlags := C.PopplerAnnotFlag(f)
+
+	C.poppler_annot_set_flags(a.am.annot, pFlags)
 }

--- a/document.go
+++ b/document.go
@@ -7,9 +7,15 @@ package poppler
 // #include <unistd.h>
 import "C"
 
+import (
+	"errors"
+	"unsafe"
+	"path/filepath"
+)
+
 type Document struct {
-	doc                poppDoc
-	openedPopplerPages []*C.struct__PopplerPage
+	doc			poppDoc
+	openedPages		[]*Page
 }
 
 type DocumentInfo struct {
@@ -41,12 +47,13 @@ func (d *Document) GetNPages() int {
 
 func (d *Document) GetPage(i int) (page *Page) {
 	p := C.poppler_document_get_page(d.doc, C.int(i))
-	d.openedPopplerPages = append(d.openedPopplerPages, p)
-	
+
 	page = &Page{
-		p:                p,
-		openedPopplerAnnotMappings: []*C.struct__PopplerAnnotMapping{},
+		p:              p,
+		openedAnnots:	nil,
 	}
+	d.openedPages = append(d.openedPages, page)
+
 	return page
 }
 
@@ -59,11 +66,82 @@ func (d *Document) GetNAttachments() int {
 }
 
 func (d *Document) Close() {
-	for i := 0; i < len(d.openedPopplerPages); i++ {
-		C.g_object_unref(C.gpointer(d.openedPopplerPages[i]))
+
+	for i := 0; i < len(d.openedPages); i++ {
+		d.openedPages[i].Close()
 	}
-	d.openedPopplerPages = []*C.struct__PopplerPage{}
+	d.openedPages = []*Page{}
+
 	C.g_object_unref(C.gpointer(d.doc))
+}
+
+func (d *Document) NewAnnot(t AnnotType, r Rectangle, q []Quad) (Annot, error) {
+	am := C.poppler_annot_mapping_new();
+
+	annot := Annot {
+		am: am,
+	}
+
+	pRect := rectangleToPopplerRectangle(r)
+
+	pQuad := quadsToGArray(q)
+	defer C.g_array_free(pQuad, 1)
+
+
+	switch (t){
+	case AnnotHighlight:
+		am.annot = C.poppler_annot_text_markup_new_highlight(d.doc, &pRect, pQuad)
+	case AnnotUnderline:
+		am.annot = C.poppler_annot_text_markup_new_underline(d.doc, &pRect, pQuad)
+	case AnnotSquiggly:
+		am.annot = C.poppler_annot_text_markup_new_squiggly(d.doc, &pRect, pQuad)
+	case AnnotStrikeOut:
+		am.annot = C.poppler_annot_text_markup_new_strikeout(d.doc, &pRect, pQuad)
+	default:
+		C.poppler_annot_mapping_free(am)
+		return annot, errors.New("invalid type for new annotation")
+	}
+
+
+	if am.annot == nil {
+		C.poppler_annot_mapping_free(am)
+		return annot, errors.New("failed to create annotation")
+	}
+
+	/* Can't get real annot mapping area as done in
+	 * poppler_page_get_annot_mapping() since page is
+	 * needed for page->page->getCropBox() and
+	 * page->page->getRotate()
+	 *
+	 * as a placeholder we just use the annot rect
+	 */
+	annot.am.area = pRect
+
+	return annot, nil
+}
+
+func (d *Document) Save(filename string) (saved bool, err error) {
+	filename, err = filepath.Abs(filename)
+	if err != nil {
+		return false, err
+	}
+
+	var e *C.GError
+	cFilename := (*C.gchar)(C.CString(filename))
+	defer C.free(unsafe.Pointer(cFilename))
+
+	cUri := C.g_filename_to_uri(cFilename, nil, nil)
+	cBool := C.poppler_document_save (d.doc, cUri, &e);
+	if e != nil {
+		err = errors.New(C.GoString((*C.char)(e.message)))
+		return false, err
+	}
+
+	if cBool == C.TRUE {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 /*

--- a/poppler.go
+++ b/poppler.go
@@ -31,7 +31,7 @@ func Open(filename string) (doc *Document, err error) {
 	}
 	doc = &Document{
 		doc:                d,
-		openedPopplerPages: []*C.struct__PopplerPage{},
+		openedPages: []*Page{},
 	}
 	return
 }

--- a/test/document_test.go
+++ b/test/document_test.go
@@ -1,0 +1,26 @@
+package poppler
+
+import (
+	"testing"
+
+	"github.com/cheggaaa/go-poppler"
+
+)
+
+func TestClosePageAndCloseDoc(t *testing.T) {
+	doc, err := poppler.Open("test.pdf")
+	defer doc.Close()
+	if err != nil {
+		return
+	}
+
+
+	n_pages := doc.GetNPages()
+
+	for i := 0; i < n_pages; i++ {
+		page := doc.GetPage(i)
+		page.Close()
+	}
+
+}
+

--- a/test/page_test.go
+++ b/test/page_test.go
@@ -1,0 +1,103 @@
+package poppler
+
+import (
+	"testing"
+	"fmt"
+
+	"github.com/cheggaaa/go-poppler"
+)
+
+func TestCloseAnnots(t *testing.T) {
+	doc, err := poppler.Open("test.pdf")
+	defer doc.Close()
+	if err != nil {
+		return
+	}
+
+
+	n_pages := doc.GetNPages()
+
+	for i := 0; i < n_pages; i++ {
+		page := doc.GetPage(i)
+		annots := page.GetAnnots()
+
+		fmt.Println("page: ", i)
+		for _, a := range annots {
+			a.Close()
+		}
+
+		page.Close()
+	}
+
+}
+
+func TestGetQuads(t *testing.T) {
+	doc, err := poppler.Open("test.pdf")
+	defer doc.Close()
+	if err != nil {
+		return
+	}
+
+
+	n_pages := doc.GetNPages()
+
+	for i := 0; i < n_pages; i++ {
+		page := doc.GetPage(i)
+		annots := page.GetAnnots()
+
+		for _, a := range annots {
+			fmt.Println(a.Quads())
+		}
+
+		page.Close()
+	}
+
+}
+
+func TestPageText(t *testing.T) {
+	doc, err := poppler.Open("test.pdf")
+	defer doc.Close()
+	if err != nil {
+		return
+	}
+
+
+	n_pages := doc.GetNPages()
+
+	for i := 0; i < n_pages; i++ {
+		page := doc.GetPage(i)
+
+		fmt.Println(page.Text())
+
+		page.Close()
+	}
+
+}
+
+func TestAnnotName(t *testing.T) {
+	doc, err := poppler.Open("test.pdf")
+	defer doc.Close()
+	if err != nil {
+		return
+	}
+
+
+	n_pages := doc.GetNPages()
+
+	for i := 0; i < n_pages; i++ {
+		page := doc.GetPage(i)
+
+		annots := page.GetAnnots()
+
+		for _, a := range annots {
+			if a.Type() == poppler.AnnotHighlight {
+				fmt.Println(a.Name())
+			}
+		}
+
+
+		page.Close()
+	}
+
+}
+

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,13 @@
 package poppler
 
+// #cgo pkg-config: poppler-glib
+// #include <poppler.h>
 // #include <glib.h>
 // #include <unistd.h>
 // #include <stdlib.h>
 import "C"
+
+import "unsafe"
 
 func toString(in *C.gchar) string {
 	return C.GoString((*C.char)(in))
@@ -11,4 +15,72 @@ func toString(in *C.gchar) string {
 
 func toBool(in C.gboolean) bool {
 	return  int(in) > 0
+}
+
+/* convert a Quad struct to a GArray */
+func quadsToGArray(quads []Quad) *C.GArray {
+	garray := C.g_array_new(C.FALSE, C.FALSE, C.sizeof_PopplerQuadrilateral)
+
+	for _, quad := range quads {
+		item := C.PopplerQuadrilateral{
+			p1: C.PopplerPoint{
+				x: C.double(quad.P1.X),
+				y: C.double(quad.P1.Y),
+			},
+			p2: C.PopplerPoint{
+				x: C.double(quad.P2.X),
+				y: C.double(quad.P2.Y),
+			},
+			p3: C.PopplerPoint{
+				x: C.double(quad.P3.X),
+				y: C.double(quad.P3.Y),
+			},
+			p4: C.PopplerPoint{
+				x: C.double(quad.P4.X),
+				y: C.double(quad.P4.Y),
+			},
+		}
+
+		C.g_array_append_vals(garray, C.gconstpointer(&item),1)
+	}
+
+	return garray
+}
+
+/* convert a GArray to a quad */
+func gArrayToQuads(q *C.GArray) []Quad {
+	length := int(q.len)
+
+	quads := make([]Quad, length)
+
+	for i := 0; i < length; i++ {
+		item := (*C.PopplerQuadrilateral)(unsafe.Pointer(uintptr(unsafe.Pointer(q.data)) + uintptr(i)*unsafe.Sizeof(C.PopplerQuadrilateral{})))
+		quads[i] = Quad{
+			P1: Point{X: float64(item.p1.x), Y: float64(item.p1.y)},
+			P2: Point{X: float64(item.p2.x), Y: float64(item.p2.y)},
+			P3: Point{X: float64(item.p3.x), Y: float64(item.p3.y)},
+			P4: Point{X: float64(item.p4.x), Y: float64(item.p4.y)},
+		}
+	}
+
+	return quads
+}
+
+func rectangleToPopplerRectangle (r Rectangle) C.PopplerRectangle {
+	var pRect C.PopplerRectangle
+
+	pRect.x1 = C.double(r.X1)
+	pRect.y1 = C.double(r.Y1)
+	pRect.x2 = C.double(r.X2)
+	pRect.y2 = C.double(r.Y2)
+
+	return pRect
+}
+
+func gFree(mem interface{}) {
+	p, ok := mem.(unsafe.Pointer)
+	if !ok {
+		panic("gFree argument should be castable to unsafe.Pointer")
+	}
+	C.g_free(C.gpointer(p))
 }


### PR DESCRIPTION
Reintroduced Close() on Annot
Added NewAnnot() and Save() to Document
Added AddAnnot() and RemoveAnnot() on Page
Added SetColor(), SetContents() and SetFlags() on Annot fixed double free error on Page.Close() (double free occurs in Doc.Close()) fixed double free error on Annot.Close() (double free occurs in Page.Close())

Also Save() document method

Fixed Annot.Quads() error for annotations that are not TEXT MARKUPs

I added some tests in the test directory 
