### PR TITLE
Fixed error on Annot.Color() if Color is not set

### DIFF
--- a/annot.go
+++ b/annot.go
@@ -109,6 +109,9 @@ func (a *Annot) Rect() Rectangle {
 
 func (a *Annot) Color() Color {
 	c := C.poppler_annot_get_color(a.am.annot)
+	if c == nil {
+		return Color{}
+	}
 	defer C.poppler_color_free(c)
 
 	color := Color{


### PR DESCRIPTION
If poppler_color is not set for a given annotations of a document you might get:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4a2f58]
```
when retrieving the color because
```
	defer C.poppler_color_free(c)
```
will dereference a nil pointer

 Changes to be committed:
	modified:   annot.go