### PR TITLE
get rid of gFree

### DIFF
--- a/page.go
+++ b/page.go
@@ -90,8 +90,7 @@ func (p *Page) TextLayout() (layouts []Rectangle) {
 	var rect *C.PopplerRectangle
 	var n C.guint
 	if toBool(C.poppler_page_get_text_layout(p.p, &rect, &n)) {
-		defer gFree(rect)
-		//defer C.g_free((C.gpointer)(rect))
+		defer C.g_free((C.gpointer)(rect))
 		layouts = make([]Rectangle, int(n))
 		r := (*[1 << 30]C.PopplerRectangle)(unsafe.Pointer(rect))[:n:n]
 		for i := 0; i < int(n); i++ {

--- a/utils.go
+++ b/utils.go
@@ -76,11 +76,3 @@ func rectangleToPopplerRectangle (r Rectangle) C.PopplerRectangle {
 
 	return pRect
 }
-
-func gFree(mem interface{}) {
-	p, ok := mem.(unsafe.Pointer)
-	if !ok {
-		panic("gFree argument should be castable to unsafe.Pointer")
-	}
-	C.g_free(C.gpointer(p))
-}


### PR DESCRIPTION
 Changes to be committed:
	modified:   page.go
	modified:   utils.go

gFree seems to be problematic, using the old C.g_free instead