### PR TITLE
Fix memory allocated for strings not being freed

### DIFF
--- a/annot.go
+++ b/annot.go
@@ -89,7 +89,7 @@ func (a *Annot) Index() int {
 
 func (a *Annot) Date() string {
 	cText := C.poppler_annot_get_modified(a.am.annot)
-	return C.GoString(cText)
+	return toString(cText)
 }
 
 func (a *Annot) Rect() Rectangle {
@@ -125,12 +125,12 @@ func (a *Annot) Color() Color {
 
 func (a *Annot) Name() string {
 	cText := C.poppler_annot_get_name(a.am.annot)
-	return C.GoString(cText)
+	return toString(cText)
 }
 
 func (a *Annot) Contents() string {
 	cText := C.poppler_annot_get_contents(a.am.annot)
-	return C.GoString(cText)
+	return toString(cText)
 }
 
 func (a *Annot) Flags() AnnotFlag {

--- a/document.go
+++ b/document.go
@@ -133,7 +133,7 @@ func (d *Document) Save(filename string) (saved bool, err error) {
 	cUri := C.g_filename_to_uri(cFilename, nil, nil)
 	cBool := C.poppler_document_save (d.doc, cUri, &e);
 	if e != nil {
-		err = errors.New(C.GoString((*C.char)(e.message)))
+		err = errors.New(toString((*C.char)(e.message)))
 		return false, err
 	}
 

--- a/page.go
+++ b/page.go
@@ -16,7 +16,7 @@ type Page struct {
 }
 
 func (p *Page) Text() string {
-	return C.GoString(C.poppler_page_get_text(p.p))
+	return toString(C.poppler_page_get_text(p.p))
 }
 
 func (p *Page) TextAttributes() (results []TextAttributes) {
@@ -207,7 +207,7 @@ func (p *Page) GetAnnots() (Annots []*Annot) {
 
 func (p *Page) AnnotText(a Annot) string {
 	cText := C.poppler_page_get_text_for_area(p.p, &a.am.area)
-	return C.GoString(cText)
+	return toString(cText)
 }
 
 func (p *Page) AddAnnot(a Annot) {

--- a/poppler.go
+++ b/poppler.go
@@ -27,7 +27,7 @@ func Open(filename string) (doc *Document, err error) {
 	var d poppDoc
 	d = C.poppler_document_new_from_file((*C.char)(fn), nil, &e)
 	if e != nil {
-		err = errors.New(C.GoString((*C.char)(e.message)))
+		err = errors.New(toString((*C.char)(e.message)))
 	}
 	doc = &Document{
 		doc:                d,
@@ -45,7 +45,7 @@ func Load(data []byte) (doc *Document, err error) {
 
 	d = C.poppler_document_new_from_bytes(b, nil, &e)
 	if e != nil {
-		err = errors.New(C.GoString((*C.char)(e.message)))
+		err = errors.New(toString((*C.char)(e.message)))
 	}
 	doc = &Document{
 		doc: d,
@@ -54,5 +54,5 @@ func Load(data []byte) (doc *Document, err error) {
 }
 
 func Version() string {
-	return C.GoString(C.poppler_get_version())
+	return toString(C.poppler_get_version())
 }


### PR DESCRIPTION
Memory allocated for strings aren't being freed properly. I replaced all instances of `C.GoString` with the existing `toString` utility that properly frees memory for each string after being converted into a go string.